### PR TITLE
Change repo url in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,9 +22,8 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/executablebooks/jupyter-book  # Online location of your book
-  path_to_book: docs  # Optional path to your book, relative to the repository root
-  branch: master  # Which branch of the repository should be used when creating links (optional)
+  url: https://github.com/benhills/wais24-radiostratigraphy  # Online location of your book
+  branch: main  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository


### PR DESCRIPTION
This will allow your readers to go to the github page and make suggestions. Right now it is pointing to JupyterBook's GitHub.